### PR TITLE
[WIP] Introduce SASS linter

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,47 @@
+# Linter Options
+options:
+  merge-default-rules: true
+
+# Rule Configuration
+rules:
+  class-name-format:
+  - 1
+  -
+    convention: 'hyphenatedlowercase'
+  mixin-name-format:
+    - 1
+    -
+      convention: 'camelcase'
+  variable-name-format:
+    - 1
+    -
+      convention: 'camelcase'
+  function-name-format:
+      - 1
+      -
+        convention: 'camelcase'
+  quotes:
+      - 1
+      -
+        style: 'double'
+  indentation:
+      - 1
+      -
+        size: 4
+  hex-notation:
+      - 1
+      -
+        style: 'lowercase'
+  hex-length:
+      - 1
+      -
+        style: 'long'
+  single-line-per-selector:
+      - 0
+  placeholder-in-extend:
+      - 0
+  empty-line-between-blocks:
+      - 1
+      -
+        include: true
+        allow-single-line-rulesets: false

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -17,31 +17,35 @@ rules:
     -
       convention: 'camelcase'
   function-name-format:
-      - 1
-      -
-        convention: 'camelcase'
+    - 1
+    -
+      convention: 'camelcase'
   quotes:
-      - 1
-      -
-        style: 'double'
+    - 1
+    -
+      style: 'double'
   indentation:
-      - 1
-      -
-        size: 4
+    - 1
+    -
+      size: 4
   hex-notation:
-      - 1
-      -
-        style: 'lowercase'
+    - 1
+    -
+      style: 'uppercase'
   hex-length:
-      - 1
-      -
-        style: 'long'
+    - 1
+    -
+      style: 'long'
   single-line-per-selector:
-      - 0
+    - 0
   placeholder-in-extend:
-      - 0
+    - 0
   empty-line-between-blocks:
-      - 1
-      -
-        include: true
-        allow-single-line-rulesets: false
+    - 1
+    -
+      include: true
+      allow-single-line-rulesets: false
+  property-sort-order:
+    - 1
+    -
+      order: 'concentric'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,7 @@ const
 	sass = require('gulp-sass'),
 	sourcemaps = require('gulp-sourcemaps'),
 	fs = require('fs'),
+    sassLint = require('gulp-sass-lint'),
 
 	// Setup
 	directories = {
@@ -110,6 +111,11 @@ function settingsExist(settings, settingsOption, settingsType) {
 
 
 function compile() {
+
+    gulp.src(directories.watch)
+        .pipe(sassLint())
+        .pipe(sassLint.format())
+        .pipe(sassLint.failOnError());
 
 	for (var task in tasks) {
 		var minify = false,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,9 +12,9 @@ const
 	plumber = require('gulp-plumber'),
 	rename = require('gulp-rename'),
 	sass = require('gulp-sass'),
+	sassLint = require('gulp-sass-lint'),
 	sourcemaps = require('gulp-sourcemaps'),
 	fs = require('fs'),
-    sassLint = require('gulp-sass-lint'),
 
 	// Setup
 	directories = {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.2",
+    "gulp-sass-lint": "^1.3.2",
     "gulp-sourcemaps": "^1.12.0"
   }
 }


### PR DESCRIPTION
This should unify code style and make contribuing easier by making sure developers use right code format. If merged, addition to #12 should be done to state, that the project follows certain code style.

To run the linter just execute `gulp`.

### Pros:
	- Remove mixing tabs and spaces
	- Set code style to contributors
	- Avoid code styling commits
### Cons:
    - Large refactoring, which will mess up git history
    - Another tool to build toolchain and new project dependency
## It introduces few conflicts rules in code:

- [ ] ([Indentation](https://github.com/sasstools/sass-lint/blob/master/docs/rules/indentation.md)).  Project uses mixed tabs and spaces. Decide which indentation it should use.
- [ ] ([Variable name format](https://github.com/sasstools/sass-lint/blob/master/docs/rules/variable-name-format.md)). Most variables use camelCase except few. (`$color-1`, `$color-2`.. in \_variables for example)

- [ ] ([Quotes](https://github.com/sasstools/sass-lint/blob/master/docs/rules/quotesmd)). Quote styles are mixed. Double quoutes (") are used most, but here and there are single quotes (') used too. My suggestion is to use double quotes and replace single quotes to avoid large scale refactoring.


- [ ] ([Hex format](https://github.com/sasstools/sass-lint/blob/master/docs/rules/hex-notation.md)) In _variables, first `$color-1` is written uppercase. Guess it is not rule, but mistake

- [ ] ([Empty line between blocks](https://github.com/sasstools/sass-lint/blob/master/docs/rules/empty-line-between-blocks.md)). There seems to be conflicts. Both variants are used. Blocks with spaces between are used more, so that should be the rule.

## There are some rules to consider allowing or disallowing:

- [ ] ([Property sort order](https://github.com/sasstools/sass-lint/blob/master/docs/rules/property-sort-order.md)) May help to unify style, but requires some refactoring

## Linter severity
Which rules should be considered error, thus fail the build?



[Lint rules](https://github.com/sasstools/sass-lint/tree/master/docs/rules) for reference
Gulp plugin: [gulp-sass-lint](https://github.com/sasstools/gulp-sass-lint)
